### PR TITLE
Fix circular import when used with other add-ons that import django.db

### DIFF
--- a/django_mysqlpool/__init__.py
+++ b/django_mysqlpool/__init__.py
@@ -1,9 +1,9 @@
 from functools import wraps
-from django.db import connection
 
 
 def auto_close_db(f):
     "Ensures the database connection is closed when the function returns."
+    from django.db import connection
     @wraps(f)
     def wrapper(*args, **kwargs):
         try:


### PR DESCRIPTION
eg sorl_thumbnail:
Traceback (most recent call last):
  File "/home/rpatterson/src/work/retrans/src/ReTransDjango/bin/manage", line 40, in <module>
    sys.exit(manage.main())
  File "/home/rpatterson/src/work/retrans/src/ReTransDjango/retrans/manage.py", line 15, in main
    execute_manager(settings)
  File "/opt/src/eggs/Django-1.3-py2.7.egg/django/core/management/**init**.py", line 438, in execute_manager
    utility.execute()
  File "/opt/src/eggs/Django-1.3-py2.7.egg/django/core/management/**init**.py", line 379, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/opt/src/eggs/Django-1.3-py2.7.egg/django/core/management/base.py", line 191, in run_from_argv
    self.execute(_args, *_options.**dict**)
  File "/opt/src/eggs/Django-1.3-py2.7.egg/django/core/management/base.py", line 209, in execute
    translation.activate('en-us')
  File "/opt/src/eggs/Django-1.3-py2.7.egg/django/utils/translation/**init**.py", line 100, in activate
    return _trans.activate(language)
  File "/opt/src/eggs/Django-1.3-py2.7.egg/django/utils/translation/trans_real.py", line 202, in activate
    _active.value = translation(language)
  File "/opt/src/eggs/Django-1.3-py2.7.egg/django/utils/translation/trans_real.py", line 185, in translation
    default_translation = _fetch(settings.LANGUAGE_CODE)
  File "/opt/src/eggs/Django-1.3-py2.7.egg/django/utils/translation/trans_real.py", line 162, in _fetch
    app = import_module(appname)
  File "/opt/src/eggs/Django-1.3-py2.7.egg/django/utils/importlib.py", line 35, in import_module
    __import__(name)
  File "/opt/src/eggs/sorl_thumbnail-11.12-py2.7.egg/sorl/thumbnail/**init**.py", line 1, in <module>
    from sorl.thumbnail.fields import ImageField
  File "/opt/src/eggs/sorl_thumbnail-11.12-py2.7.egg/sorl/thumbnail/fields.py", line 2, in <module>
    from django.db import models
  File "/opt/src/eggs/Django-1.3-py2.7.egg/django/db/**init**.py", line 78, in <module>
    connection = connections[DEFAULT_DB_ALIAS]
  File "/opt/src/eggs/Django-1.3-py2.7.egg/django/db/utils.py", line 94, in **getitem**
    backend = load_backend(db['ENGINE'])
  File "/opt/src/eggs/Django-1.3-py2.7.egg/django/db/utils.py", line 47, in load_backend
    if backend_name not in available_backends:
django.core.exceptions.ImproperlyConfigured: 'django_mysqlpool.backends.mysqlpool' isn't an available database backend.
Try using django.db.backends.XXX, where XXX is one of:
    'dummy', 'mysql', 'oracle', 'postgresql', 'postgresql_psycopg2', 'sqlite3'
Error was: cannot import name connection
