### PR TITLE
Upgrade SQLAlchemy dependency

### DIFF
--- a/django_mysqlpool/__init__.py
+++ b/django_mysqlpool/__init__.py
@@ -12,7 +12,7 @@ __metaclass__ = type
 from functools import wraps
 
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"
 
 
 def auto_close_db(f):

--- a/django_mysqlpool/backends/mysqlpool/base.py
+++ b/django_mysqlpool/backends/mysqlpool/base.py
@@ -5,12 +5,7 @@
 from __future__ import (absolute_import, print_function, unicode_literals,
                         division)
 
-# Make ``Foo()`` work the same in Python 2 as it does in Python 3.
-__metaclass__ = type
-
-
 import os
-
 
 from django.conf import settings
 from django.db.backends.mysql import base
@@ -20,6 +15,10 @@ try:
     import sqlalchemy.pool as pool
 except ImportError as e:
     raise ImproperlyConfigured("Error loading SQLAlchemy module: %s" % e)
+
+
+# Make ``Foo()`` work the same in Python 2 as it does in Python 3.
+__metaclass__ = type
 
 
 # Global variable to hold the actual connection pool.

--- a/django_mysqlpool/backends/mysqlpool/base.py
+++ b/django_mysqlpool/backends/mysqlpool/base.py
@@ -64,16 +64,31 @@ class HashableDict(dict):
 
     This is not generally useful, but created specifically to hold the ``conv``
     parameter that needs to be passed to MySQLdb.
+
+    Thanks to `Alex Martelli`_ for the implementation.
+
+    .. _Alex Martelli: https://stackoverflow.com/a/1151686
     """
+
+    def __key(self):
+        return tuple((k, self[k]) for k in sorted(self))
 
     def __hash__(self):
         """Calculate the hash of this ``dict``.
 
-        The hash is determined by converting to a sorted tuple of key-value
-        pairs and hashing that.
+        The hash is determined by converting to a sorted tuple of
+        key-value pairs and hashing that.
         """
-        items = [(n, tuple(v)) for n, v in self.items if isiterable(v)]
-        return hash(tuple(items))
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        """Determine whether ``other`` is equal to this ``dict``.
+
+        The implementation of this comparison uses the same underlying
+        mechanism as ``__hash__``, in order to guarantee that ``==`` and
+        ``.hash`` are in sync.
+        """
+        return self.__key() == other.__key()
 
 
 # Define this here so Django can import it.

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from setuptools import setup, find_packages
 
 
 REQUIRES = [
-    "sqlalchemy >=0.7, <1.0",
+    "SQLAlchemy >=1.0, <2.0",
 ]
 
 


### PR DESCRIPTION
SQLAlchemy went 1.0 a while back, and being tied to pre-1.0 makes this harder to use. I've got projects that depend on 1.0 or better that also need this lib, so the transitive dependency conflict is problematic.

As a side-effect of the version bump on SQLAlchemy, the `HashableDict` implementation was throwing an error, so I also had to revisit it. Happily, I think the new implementation is more robust.

I also bumped the version number, so it would be easy to cut a new release for PyPI.